### PR TITLE
适配旧教务系统中"美育选课"

### DIFF
--- a/generate-userscript.py
+++ b/generate-userscript.py
@@ -25,8 +25,8 @@ prefix = '''// ==UserScript==
 
 '''
 
-with open("js/inject.js", "r") as fin:
-  with open("potatoplus.user.js", "w") as fout:
+with open("js/inject.js", "r", encoding="utf-8") as fin:
+  with open("potatoplus.user.js", "w", encoding="utf-8") as fout:
     fout.write(prefix);
     lines = fin.readlines()
     for line in lines:
@@ -39,7 +39,7 @@ with open("js/inject.js", "r") as fin:
         fout.write("\n/* " + filename + " */\n")
         if line.find("injectStyle(\"") != -1:
           fout.write("injectStyleFromString(`")
-        with open(filename, "r") as lib:
+        with open(filename, "r", encoding="utf-8") as lib:
           lines2 = lib.readlines()
           for line2 in lines2:
             if line2.find("@platform@") != -1:

--- a/js/inject.js
+++ b/js/inject.js
@@ -46,6 +46,7 @@ function injectStyleFromString(str) {
 
     read_view: /elective\/readCourseList.do/i, // 经典导读读书班初选
     dis_view: /elective\/freshman_discuss.do/i, // 导学、研讨、通识课初选
+    art_view: /elective\/artList.do/i, // 美育课程初选
     public_view: /elective\/publicCourseList.do/i, // 公选课初选
     open_view: /elective\/open.do/i, // 跨专业初选
 

--- a/js/pjw-core.js
+++ b/js/pjw-core.js
@@ -98,7 +98,7 @@ window.potatojw_intl = function() {
   }
 
   var filter_mode_list = {"major_course": 6};
-  var pjw_classlist_mode_list = {"dis_view": true, "open_view": true, "all_course_list": true, "dis": true, "open": true, "common": true, "public": true, "read_view": true, "gym": true, "read": true, "grade_info": true, "public_view": true, "union": true, "course": true};
+  var pjw_classlist_mode_list = {"dis_view": true, "art_view": true, "open_view": true, "all_course_list": true, "dis": true, "open": true, "common": true, "public": true, "read_view": true, "gym": true, "read": true, "grade_info": true, "public_view": true, "union": true, "course": true};
 
   const custom_toolbar_html = {
     course_eval: `
@@ -698,7 +698,7 @@ window.potatojw_intl = function() {
     enterMode("common");
   } else if (pjw_mode == "dis" || pjw_mode == "public") {
     enterMode("dis_public");
-  } else if (pjw_mode == "dis_view" || pjw_mode == "public_view") {
+  } else if (pjw_mode == "dis_view" || pjw_mode == "public_view" || pjw_mode == "art_view") {
     enterMode("dis_public_view");
   } else if (pjw_mode == "open") {
     enterMode("open");

--- a/js/pjw-modes.js
+++ b/js/pjw-modes.js
@@ -1277,7 +1277,16 @@ function() {
         type: "POST",
         url: "/jiaowu/student/elective/courseList.do",
         data: {
-          method: pjw_select_mode == "dis_view" ? "discussGeneralCourse" : "publicCourseList"
+          method: () =>{
+            switch(pjw_select_mode){
+              case "dis_view":
+                return "discussGeneralCourse";
+              case "art_view":
+                return "artCourseList";
+              default:
+                return "publicCourseList";
+            }
+          }
         }
       }).done((data) => {
         this.ajax_request = null;
@@ -1293,7 +1302,16 @@ function() {
     type: "POST",
     url: "/jiaowu/student/elective/courseList.do",
     data: {
-      method: pjw_select_mode == "dis_view" ? "discussGeneralCourse" : "publicCourseList"
+      method: () =>{
+        switch(pjw_select_mode){
+          case "dis_view":
+            return "discussGeneralCourse";
+          case "art_view":
+            return "artCourseList";
+          default:
+            return "publicCourseList";
+        }
+      }
     }
   }).done((data) => {
     list.selectors = {

--- a/js/pjw-modes.js
+++ b/js/pjw-modes.js
@@ -1277,14 +1277,16 @@ function() {
         type: "POST",
         url: "/jiaowu/student/elective/courseList.do",
         data: {
-          method: () =>{
-            switch(pjw_select_mode){
+          method: () => {
+            switch (pjw_select_mode) {
               case "dis_view":
                 return "discussGeneralCourse";
               case "art_view":
                 return "artCourseList";
-              default:
+              case "public_view":
                 return "publicCourseList";
+              default:
+                // WILL NOT BE EXECUTED
             }
           }
         }
@@ -1302,14 +1304,16 @@ function() {
     type: "POST",
     url: "/jiaowu/student/elective/courseList.do",
     data: {
-      method: () =>{
-        switch(pjw_select_mode){
+      method: () => {
+        switch (pjw_select_mode) {
           case "dis_view":
             return "discussGeneralCourse";
           case "art_view":
             return "artCourseList";
-          default:
+          case "public_view":
             return "publicCourseList";
+          default:
+            // WILL NOT BE EXECUTED
         }
       }
     }


### PR DESCRIPTION
发现 http://elite.nju.edu.cn/jiaowu/student/elective/artList.do 这个链接的美育选课没有适配 PotatoPlus 的功能.
(美育选课是 2021 新生特定的吗...? 为什么之前没有适配呢?)

于是自己改了一点代码交 PR.
用我自己账号简单测试了一下, 功能正常.

我只改了代码, 不知道是否需要改小版本号发 Release?
![QQ截图20210915180756](https://user-images.githubusercontent.com/36782264/133430073-d9232a15-3cdd-4aed-a006-0acd291edf85.png)

